### PR TITLE
remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13767,12 +13767,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "minipass": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5448,7 +5448,8 @@
     "caniuse-lite": {
       "version": "1.0.30001120",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001120.tgz",
-      "integrity": "sha512-JBP68okZs1X8D7MQTY602jxMYBmXEKOFkzTBaNSkubooMPFOAv2TXWaKle7qgHpjLDhUzA/TMT0qsNleVyXGUQ=="
+      "integrity": "sha512-JBP68okZs1X8D7MQTY602jxMYBmXEKOFkzTBaNSkubooMPFOAv2TXWaKle7qgHpjLDhUzA/TMT0qsNleVyXGUQ==",
+      "dev": true
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20080,16 +20080,6 @@
         }
       }
     },
-    "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
     "yazl": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19165,12 +19165,6 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
-    "utils-extend": {
-      "version": "npm:utils-extend-patched@1.0.9",
-      "resolved": "https://registry.npmjs.org/utils-extend-patched/-/utils-extend-patched-1.0.9.tgz",
-      "integrity": "sha512-yTSTfNOVUNFOFXeJl+wSenaSZfZ5RgQB6HVUvx/XgUCthC71J/5dMDHXAqKqZdwOwVbIYRFj4x0MywU7tOiP7Q==",
-      "dev": true
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5563,23 +5563,6 @@
         }
       }
     },
-    "clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "dev": true,
-      "requires": {
-        "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3",
     "url-loader": "^4.1.1",
-    "utils-extend": "npm:utils-extend-patched@^1.0.9",
     "webpack": "^4.41.6",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -96,11 +96,5 @@
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^5.4.0"
-  },
-  "resolutions": {
-    "clean-css": "^4.2.3",
-    "minimist": "^1.2.5",
-    "yargs-parser": "^18.1.3",
-    "utils-extend": "npm:utils-extend-patched@^1.0.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@maplat/tin": "^0.6.7",
     "@turf/turf": "^5.1.6",
     "argv": "0.0.2",
-    "caniuse-lite": "^1.0.30001120",
     "i18next": "^17.3.1",
     "i18next-xhr-backend": "^3.2.2",
     "lodash.template": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "less": "^3.13.1",
     "less-loader": "^7.1.0",
     "mini-css-extract-plugin": "^1.3.3",
-    "minimist": "^1.2.5",
     "prettier": "^2.2.1",
     "serialize-javascript": "^4.0.0",
     "terser-webpack-plugin": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test": "jest",
     "preversion": "npm run lint & npm run test",
     "version": "npm run build && npm run build_packed && git add -A",
-    "preinstall": "npx npm-force-resolutions || echo 'ignore'",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint \"{src,spec}/**/*.{js,ts}\" --fix",
     "lint:prettier": "prettier \"./{src,spec}/**/*.{js,ts}\" --write",

--- a/package.json
+++ b/package.json
@@ -95,8 +95,7 @@
     "webpack": "^4.41.6",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",
-    "webpack-merge": "^5.4.0",
-    "yargs-parser": "^18.1.3"
+    "webpack-merge": "^5.4.0"
   },
   "resolutions": {
     "clean-css": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@typescript-eslint/parser": "^4.10.0",
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
-    "clean-css": "^4.2.3",
     "clean-webpack-plugin": "^3.0.0",
     "core-js": "^3.8.1",
     "css-loader": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "less-loader": "^7.1.0",
     "mini-css-extract-plugin": "^1.3.3",
     "prettier": "^2.2.1",
-    "serialize-javascript": "^4.0.0",
     "terser-webpack-plugin": "^4.2.3",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3",


### PR DESCRIPTION
# Why

依存関係が以下のようになっており, #11 で `base64-img` はアンインストールされたことで不要なdependenciesがpackage.jsonに残っていたから

```
base64-img
├── ajax-request
└── file-system

ajax-request
├── utils-extend
└── file-system

file-system
├── utils-extend
└── file-match

file-match
└── utils-extend
```

# Done
- [x] uninstall caniuse-lite
- [x] uninstall minimist
- [x] uninstall serialize-javascript
- [x] uninstall clean-css
- [x] uninstall utils-extend
- [x] uninstall yargs-parser
- [x] remove `resolutions` and `scripts:preinstall` in package.json